### PR TITLE
Build on theta

### DIFF
--- a/3rdParty/gslib/Makefile
+++ b/3rdParty/gslib/Makefile
@@ -1,3 +1,11 @@
+ifndef OCCA_DIR
+ERROR:
+	@echo "Error, environment variable [OCCA_DIR] is not set"
+endif
+
+PROJ_DIR=$(CURDIR)
+include $(OCCA_DIR)/scripts/Makefile
+
 MPI ?= 1
 MPIIO ?= 1
 ADDUS ?= 1
@@ -58,8 +66,14 @@ G+=-DGLOBAL_LONG_LONG
 #G+=-DPRINT_MALLOCS=1
 #G+=-DGS_TIMING -DGS_BARRIER
 
-CCCMD=$(CC) $(CFLAGS) -I$(INCDIR) $(G)
-FCCMD=$(FC) $(FFLAGS)
+#CCCMD=$(CC) $(CFLAGS) -I$(INCDIR) $(G)
+#FCCMD=$(FC) $(FFLAGS)
+
+cCompilerFlags += $(G)
+paths += -I$(INCDIR)
+
+CCCMD=$(cCompiler) $(cCompilerFlags) $(paths)
+FCCMD=$(FC) $(cCompilerFlags) $(paths)
 
 LINKCMD=$(CC) $(CFLAGS) -I$(INCDIR) $(G) $^ -o $@ -L$(SRCDIR) \
         -l$(LIBNAME) -lm $(LDFLAGS)

--- a/3rdParty/ogs/makefile
+++ b/3rdParty/ogs/makefile
@@ -3,21 +3,34 @@ ERROR:
 	@echo "Error, environment variable [OCCA_DIR] is not set"
 endif
 
+PROJ_DIR=$(CURDIR)
 include ${OCCA_DIR}/scripts/Makefile
 
 # define variables
-OGSDIR  = ./include
-GSDIR  = ../../3rdParty/gslib
+OGSDIR  = $(CURDIR)
+GSDIR  ?= ../../3rdParty/gslib
 
 # set options for this machine
 # specify which compilers to use for c, fortran and linking
 
 # compiler flags to be used (set to compile with debugging on)
-CFLAGS += -I. -I$(GSDIR)/src -DDOGS='"${CURDIR}"' -DUSE_NEW_PINNED_MALLOC=1
-CXXFLAGS += -I. -I$(GSDIR)/src -DDOGS='"${CURDIR}"' -DUSE_NEW_PINNED_MALLOC=1
+
+paths += -I$(OGSDIR)
+paths += -I$(OGSDIR)/include
+paths += -I$(GSDIR)/src
+paths += -L$(OCCA_DIR)/lib
+paths += -L$(GSDIR)/lib
+
+cCompilerFlags += $(DEFS)
+cCompilerFlags += -DDOGS='"${CURDIR}"'
+cCompilerFlags += -DUSE_NEW_PINNED_MALLOC=1
+
+compilerFlags += $(DEFS)
+compilerFlags += -DDOGS='"${CURDIR}"' 
+compilerFlags += -DUSE_NEW_PINNED_MALLOC=1
 
 # libraries to be linked in
-LIBS	=   -L$(OCCA_DIR)/lib  $(links) -L$(GSDIR)/lib  -lgs 
+linkerFlags	+= -lgs 
 
 #-llapack -lblas
 
@@ -30,10 +43,10 @@ $(HDRDIR)/types.h
 
 # rule for .c files
 .c.o: $(DEPS)
-	$(CC) $(CFLAGS) -o $*.o -c $*.c $(paths)
+	$(cCompiler) -c $(cCompilerFlags) $(paths) $*.c -o $*.o
 
 .cpp.o: $(DEPS)
-	$(CXX) $(CXXFLAGS) -o $*.o -c $*.cpp $(paths)
+	$(compiler) -c $(compilerFlags) $(paths) $*.cpp -o $*.o
 
 # list of objects to be compiled
 OBJS    = \
@@ -62,28 +75,18 @@ COBJS = \
 ./src/ogsHostSetup.o
 
 
-lib:$(OBJS) gslibInterface
+lib:$(OBJS) gslibInterface $(COBJS)
 	ar -cr libogs.a $(OBJS) $(COBJS)
 
 gslibInterface:
-	CC=$(CC) $(MAKE) -C ../../3rdParty/gslib -j install
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostGatherScatter.o     ./src/ogsHostGatherScatter.c     $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostGatherScatterVec.o  ./src/ogsHostGatherScatterVec.c  $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostGatherScatterMany.o ./src/ogsHostGatherScatterMany.c $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostGather.o        ./src/ogsHostGather.c        $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostGatherVec.o     ./src/ogsHostGatherVec.c     $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostGatherMany.o    ./src/ogsHostGatherMany.c    $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostScatter.o       ./src/ogsHostScatter.c       $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostScatterVec.o    ./src/ogsHostScatterVec.c    $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostScatterMany.o   ./src/ogsHostScatterMany.c   $(paths)
-	$(CC) $(CFLAGS) -c -o ./src/ogsHostSetup.o         ./src/ogsHostSetup.c         $(paths)
+	$(MAKE) -C ../../3rdParty/gslib -j install
 
 all: lib
 
 clean:
-	rm src/*.o libogs.a
+	rm -f src/*.o libogs.a
 
 realclean:
 	cd ../../3rdParty/gslib; make clean; cd ../../3rdParty/ogs
-	rm src/*.o libogs.a
+	rm -f src/*.o libogs.a
 

--- a/axhelm/kernelHelper.cpp
+++ b/axhelm/kernelHelper.cpp
@@ -31,22 +31,22 @@ static occa::kernel loadAxKernel(occa::device device, const std::string threadMo
   props["defines/dfloat"] = dfloatString;
   props["defines/dlong"]  = dlongString;
 
-  props["okl"] = false;
-
   occa::kernel axKernel;
 
   std::string filename = "kernel/" + arch + "/axhelm";
   for (int r=0;r<2;r++){
     if ((r==0 && rank==0) || (r==1 && rank>0)) {
       if(strstr(threadModel.c_str(), "NATIVE+CUDA")){
+         props["okl"] = false;
         axKernel = device.buildKernel(filename + ".cu", kernelName, props);
         axKernel.setRunDims(Nelements, Nq*Nq);
       } else if(strstr(threadModel.c_str(), "NATIVE+SERIAL") || 
                 strstr(threadModel.c_str(), "NATIVE+OPENMP")){
+         props["okl"] = false;
         props["defines/USE_OCCA_MEM_BYTE_ALIGN"] = USE_OCCA_MEM_BYTE_ALIGN;
         axKernel = device.buildKernel(filename + ".c", kernelName, props);
       } else { // fallback is okl
-        props["okl"] = true;
+        //props["okl"] = true;
         axKernel = device.buildKernel(filename + ".okl", kernelName, props);
       }
     }

--- a/axhelm/makefile
+++ b/axhelm/makefile
@@ -1,30 +1,36 @@
 WS ?= 8
 
-PROJ_DIR=./
-CORE_DIR=$(HDRDIR)
+PROJ_DIR=$(CURDIR)
+include ${OCCA_DIR}/scripts/Makefile
 
 ifeq (0,$(MAKELEVEL))
 ERROR:
 	@echo "ERROR:  Please use toplevel makefile"
 endif
 
+paths += -I$(HDRDIR)
+paths += -L$(OCCA_DIR)/lib
+
+compilerFlags += $(DEFS)
+
+ifeq ($(USE_SYSTEM_BLASLAPACK),no)
+	linkerFlags += $(BLASLAPACK_DIR)/libBlasLapack.a
+endif
+
 .PHONY: all install clean realclean
 
 all: axhelm install
 
-axhelm: main.cpp ${CORE_DIR}/meshBasis.cpp libblas
-	$(CXX) $(CXXFLAGS) -o axhelm main.cpp ${CORE_DIR}/meshBasis.cpp $(linkerFlags) $(LDFLAGS)
+axhelm: main.cpp $(HDRDIR)/meshBasis.cpp
+	$(compiler) $(compilerFlags) $(paths) $^ -o $(@) $(linkerFlags)
 
 $(oPath)/%.o:$(sPath)/%.cpp $(wildcard $(subst $(sPath)/,$(iPath)/,$(<:.cpp=.hpp))) $(wildcard $(subst $(sPath)/,$(iPath)/,$(<:.cpp=.tpp)))
-	$(CXX) $(CXXFLAGS) -o $@ -c $<
+	$(compiler) -c $(compilerFlags) $(paths) $< -o $(@)
 
 install:
 	@mkdir -p $(PREFIX)/kernel
 	@cd kernel && find . -type f -name "*" -exec install -D {} $(PREFIX)/kernel/{} \; && cd ..
 	@mv axhelm $(PREFIX) 
-
-libblas:
-	@cd ../3rdParty/BlasLapack; $(MAKE) -j4 lib
 
 clean:
 	@rm -f ${PROJ_DIR}/axhelm

--- a/makefile
+++ b/makefile
@@ -1,51 +1,75 @@
-export OCCA_DIR = $(CURDIR)/3rdParty/occa
-include ${OCCA_DIR}/scripts/Makefile
-
-export CC = mpicc
-export FC = mpif77
-export CXX = mpic++
-export LD = mpic++
-
-export NALIGN ?= 64
 export PREFIX ?= $(CURDIR)/build
+export NALIGN ?= 64
 
-export OCCA_CUDA_ENABLED ?= 0
-export OCCA_HIP_ENABLED ?= 0
-export OCCA_OPENCL_ENABLED ?= 0
+export CC	= mpicc
+export FC	= mpif77
+export CXX= mpic++
+export LD	= mpic++
+
+export CFLAGS		= -O3 -fopenmp
+export CXXFLAGS = -O3 -fopenmp
+export LDFLAGS 	=  -fopenmp
+
+# Bypass MPI compiler wrappers and handle linking ourselves
+#export USE_MPI_WRAPPER = no
+#export MPI_DIR = $(MPICH_DIR)
+#export MPI_LIBFLAG = -lmpich
+
+# Use an external BLAS/LAPACK library
+#export USE_SYSTEM_BLASLAPACK = yes
+#export BLASLAPACK_LIBFLAG = -mkl
+
+export OCCA_DIR = $(CURDIR)/3rdParty/occa
+export OCCA_INCLUDE_PATH 	?=
+export OCCA_LIBRARY_PATH 	?=
+export OCCA_CUDA_ENABLED	?= 0
+export OCCA_HIP_ENABLED 	?= 0
+export OCCA_OPENCL_ENABLED?= 0
 export OCCA_METAL_ENABLED ?= 0
 
-flags += -g
-flags += -Ddfloat=double
-flags += -DdfloatString='"double"'
-flags += -DMPI_DFLOAT='MPI_DOUBLE'
-flags += -DdfloatFormat='"%lf"'
-flags += -Ddlong=int
-flags += -DdlongString='"int"'
-flags += -DMPI_DLONG='MPI_INT'
-flags += -DdlongFormat='"%d"'
-flags += -Dhlong='long long int'
-flags += -DhlongString='"long long int"'
-flags += -DMPI_HLONG='MPI_LONG_LONG_INT'
-flags += -DhlongFormat='"%lld"'
-flags += -DUSE_OCCA_MEM_BYTE_ALIGN=$(NALIGN)
+DEFS = -Ddfloat=double
+DEFS += -DdfloatString='"double"'
+DEFS += -DMPI_DFLOAT='MPI_DOUBLE'
+DEFS += -DdfloatFormat='"%lf"'
+DEFS += -Ddlong=int
+DEFS += -DdlongString='"int"'
+DEFS += -DMPI_DLONG='MPI_INT'
+DEFS += -DdlongFormat='"%d"'
+DEFS += -Dhlong='long long int'
+DEFS += -DhlongString='"long long int"'
+DEFS += -DMPI_HLONG='MPI_LONG_LONG_INT'
+DEFS += -DhlongFormat='"%lld"'
+DEFS += -DUSE_OCCA_MEM_BYTE_ALIGN=$(NALIGN)
+DEFS += -DOCCA_VERSION_1_0 
+DEFS += -D DBP='"./"'
+export DEFS
 
-export HDRDIR = $(CURDIR)/core
-export GSDIR  = $(CURDIR)/3rdParty/gslib/
-export OGSDIR = $(CURDIR)/3rdParty/ogs/
-export BLASLAPACK_DIR = $(CURDIR)/3rdParty/BlasLapack
+export HDRDIR = ${CURDIR}/core
+export GSDIR  = ${CURDIR}/3rdParty/gslib
+export OGSDIR = ${CURDIR}/3rdParty/ogs
+export BLASLAPACK_DIR := $(CURDIR)/3rdParty/BlasLapack
 
-NEKBONEDIR = ./nekBone 
+NEKBONEDIR = ./nekBone
+NEKBONEDEPS= libogs
+
 AXHELMDIR  = ./axhelm 
+AXHELMDEPS = 
 
-export CFLAGS = -I. -DOCCA_VERSION_1_0 $(cCompilerFlags) $(flags) -I$(HDRDIR) -I$(OGSDIR) -I$(OGSDIR)/include  -D DBP='"./"' $(paths)
+ifeq ($(USE_SYSTEM_BLASLAPACK),yes)
+export LDFLAGS += $(BLASLAPACK_LIBFLAG)	
+else
+NEKBONEDEPS += libblas
+AXHELMDEPS += libblas
+export LDFLAGS += -lgfortran 
+endif
 
-export CXXFLAGS = -I. -DOCCA_VERSION_1_0 $(compilerFlags) $(flags) -I$(HDRDIR) -I$(OGSDIR) -I$(OGSDIR)/include  -D DBP='"./"' $(paths)
+ifeq ($(USE_MPI_WRAPPER),no)
+export LDFLAGS += $(MPI_LIBFLAG)
+export OCCA_INCLUDE_PATH += $(MPI_DIR)/include
+export OCCA_LIBRARY_PATH += $(MPI_DIR)/lib
+endif
 
-LDFLAGS = $(BLASLAPACK_DIR)/libBlasLapack.a -lgfortran -fopenmp
-LDFLAGS_OCCA = -L$(OCCA_DIR)/lib -locca
-LDFLAGS_GS = -L$(OGSDIR) -logs -L$(GSDIR)/lib -lgs 
-
-.PHONY: install axhelm nekBone all clean realclean
+.PHONY: install axhelm nekBone libogs libblas all clean realclean
 
 all: occa axhelm nekBone install
 	@if test -f ${PREFIX}/axhelm && test -f ${PREFIX}/nekBone; then \
@@ -57,11 +81,11 @@ all: occa axhelm nekBone install
 install:
 	@rm -rf $(PREFIX)/libgs.a
 
-axhelm:
-	LDFLAGS="$(LDFLAGS_OCCA) $(LDFLAGS)" $(MAKE) -C $(AXHELMDIR) 
+axhelm: $(AXHELMDEPS)
+	$(MAKE) -C $(AXHELMDIR) 
 
-nekBone:
-	LDFLAGS="$(LDFLAGS_OCCA) $(LDFLAGS_GS) $(LDFLAGS)" $(MAKE) -C $(NEKBONEDIR)
+nekBone: $(NEKBONEDEPS)
+	$(MAKE) -C $(NEKBONEDIR)
 
 occa:
 	$(MAKE) -j8 -C $(OCCA_DIR)
@@ -69,9 +93,18 @@ occa:
 	@rm -rf ${PREFIX}/bin
 	@rm -rf ${PREFIX}/include
 
+libogs:
+	$(MAKE) -C $(OGSDIR) -j4 lib
+
+libblas:
+	$(MAKE) -C $(BLASLAPACK_DIR) -j4 lib
+
 clean:
-	@$(MAKE) -C $(NEKBONEDIR) realclean
+	@$(MAKE) -C $(NEKBONEDIR) clean
 	@$(MAKE) -C $(AXHELMDIR) realclean
+	@$(MAKE) -C $(OGSDIR) realclean
+	@CC=$(CC) $(MAKE) -C $(BLASLAPACK_DIR) clean
 
 realclean: clean
 	@$(MAKE) -C $(OCCA_DIR) clean
+	@rm -rf ${PREFIX}

--- a/nekBone/makefile
+++ b/nekBone/makefile
@@ -3,6 +3,24 @@ ERROR:
 	@echo "ERROR:  Please use toplevel makefile"
 endif
 
+PROJ_DIR=$(CURDIR)
+include $(OCCA_DIR)/scripts/Makefile
+
+paths += -I$(HDRDIR)
+paths += -I$(GSDIR)/src
+paths += -I$(OGSDIR)
+paths += -L$(OCCA_DIR)/lib
+paths += -L$(GSDIR)/lib
+paths += -L$(OGSDIR)
+
+compilerFlags += $(DEFS)
+
+linkerFlags += -logs -lgs
+
+ifeq ($(USE_SYSTEM_BLASLAPACK),no)
+	linkerFlags += $(BLASLAPACK_DIR)/libBlasLapack.a
+endif
+
 INCLUDES = BP.h BPPrecon.h
 DEPS = $(INCLUDES) \
 $(HDRDIR)/timer.hpp \
@@ -17,13 +35,13 @@ $(OGSDIR)/ogs.hpp \
 
 # rule for .c files
 .c.o: $(DEPS)
-	$(CC) $(CFLAGS) -o $*.o -c $*.c 
+	$(cCompiler) $(cCompilerFlags) $(paths) -o $*.o -c $*.c 
 
 .cpp.o: $(DEPS)
-	$(CXX) $(CXXFLAGS) -o $*.o -c $*.cpp
+	$(compiler) $(compilerFlags) $(paths) -o $*.o -c $*.cpp
 
 .f.o: $(DEPS)
-	$(FC) $(CFLAGS) -o $*.o -c $*.f 
+	$(FC) $(cCompilerFlags) $(paths) -o $*.o -c $*.f 
 
 # list of objects to be compiled
 AOBJS    = \
@@ -50,19 +68,8 @@ install:
 	@cd $(CURDIR)	 
 	@mv nekBone $(PREFIX) 
 
-
-BP: $(AOBJS) $(LOBJS) libogs libblas
-	$(LD)  -o nekBone $(COBJS) $(AOBJS) $(LOBJS) $(LDFLAGS)
-
-libogs:
-	$(MAKE) -C $(OGSDIR) -j4 lib
-
-libblas:
-	$(MAKE) -C $(BLASLAPACK_DIR) -j4 lib
+BP: $(AOBJS) $(LOBJS)
+	$(compiler) $(compilerFlags) $(paths) $^ -o nekBone $(linkerFlags)
 
 clean:
 	@rm -rf *.o ../core/*.o ./build
-
-realclean: clean
-	@$(MAKE) -C $(OGSDIR) realclean
-	@CC=$(CC) make -C $(BLASLAPACK_DIR) clean


### PR DESCRIPTION
To make builds easier on HPC systems&mdash;such as Theta@ALCF

- An option to bypass the MPI compiler wrappers and link directly to the MPI library has been added.
- The `occa/scripts/Makefile` is called in the makefiles of each subdirectory to ensure the appropriate compiler flags are set (e.g. for generating shared libraries). 
- Build recipes in ogs and gs are updated to use variables defined by the `occa/script/Makefile`

Additionally, an option to link to an external BLAS/LAPACK library has been added.