### PR TITLE
Fix: kernel on interior and compilation on PowerPC

### DIFF
--- a/3rdParty/occa/include/occa/scripts/shellTools.sh
+++ b/3rdParty/occa/include/occa/scripts/shellTools.sh
@@ -224,6 +224,7 @@ function compilerVendor {
     local b_HP=6
     local b_VisualStudio=7
     local b_Cray=8
+    local b_PPC=9
 
     local testFilename="${SCRIPTS_DIR}/tests/compiler.cpp"
     local binaryFilename="${SCRIPTS_DIR}/tests/compiler"
@@ -243,6 +244,7 @@ function compilerVendor {
         "${b_HP}")           echo HP           ;;
         "${b_Cray}")         echo CRAY         ;;
         "${b_VisualStudio}") echo VISUALSTUDIO ;;
+        "${b_PPC}")          echo POWERPC      ;;
         *)                   echo N/A          ;;
     esac
 }
@@ -251,7 +253,7 @@ function compilerCpp11Flags {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM|INTEL|PGI)
+        GCC|LLVM|INTEL|PGI|POWERPC)
             echo "-std=c++11";;
         CRAY)      echo "-hstd=c++11"          ;;
         IBM)       echo "-qlanglvl=extended0x" ;;
@@ -267,13 +269,14 @@ function compilerReleaseFlags {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM)   echo " -O3 -march=native -D __extern_always_inline=inline" ;;
-        INTEL)      echo " -O3 -xHost"                                         ;;
-        CRAY)       echo " -O3 -h intrinsics -fast"                            ;;
-        IBM)        echo " -O3 -qhot=simd"                                     ;;
-        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc"           ;;
-        PATHSCALE)  echo " -O3 -march=auto"                                    ;;
-        HP)         echo " +O3"                                                ;;
+        GCC|LLVM)   echo " -O3 -march=native -D __extern_always_inline=inline"              ;;
+        POWERPC)    echo " -O3 -mcpu=native -mtune=native -D __extern_always_inline=inline" ;;
+        INTEL)      echo " -O3 -xHost"                                                      ;;
+        CRAY)       echo " -O3 -h intrinsics -fast"                                         ;;
+        IBM)        echo " -O3 -qhot=simd"                                                  ;;
+        PGI)        echo " -O3 -fast -Mipa=fast,inline -Msmartalloc"                        ;;
+        PATHSCALE)  echo " -O3 -march=auto"                                                 ;;
+        HP)         echo " +O3"                                                             ;;
         *)          ;;
     esac
 }
@@ -291,7 +294,7 @@ function compilerPicFlag {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI)
+        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI|POWERPC)
             echo "-fPIC";;
         IBM) echo "-qpic";;
         HP)  echo "+z";;
@@ -303,7 +306,7 @@ function compilerSharedFlag {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI)
+        GCC|LLVM|INTEL|PATHSCALE|CRAY|PGI|POWERPC)
             echo "-shared";;
         IBM) echo "-qmkshrobj";;
         HP)  echo "-b";;
@@ -319,13 +322,13 @@ function compilerOpenMPFlag {
     local vendor=$(compilerVendor "$1")
 
     case "$vendor" in
-        GCC|LLVM)        echo "-fopenmp" ;;
-        INTEL|PATHSCALE) echo "-openmp"  ;;
-        CRAY)            echo ""         ;;
-        IBM)             echo "-qsmp"    ;;
-        PGI)             echo "-mp"      ;;
-        HP)              echo "+Oopenmp" ;;
-        *)               echo ""         ;;
+        GCC|LLVM|POWERPC) echo "-fopenmp" ;;
+        INTEL|PATHSCALE)  echo "-openmp"  ;;
+        CRAY)             echo ""         ;;
+        IBM)              echo "-qsmp"    ;;
+        PGI)              echo "-mp"      ;;
+        HP)               echo "+Oopenmp" ;;
+        *)                echo ""         ;;
     esac
 }
 

--- a/3rdParty/occa/include/occa/scripts/tests/compiler.cpp
+++ b/3rdParty/occa/include/occa/scripts/tests/compiler.cpp
@@ -7,7 +7,8 @@
 #define OCCA_HP_VENDOR           6
 #define OCCA_VISUALSTUDIO_VENDOR 7
 #define OCCA_CRAY_VENDOR         8
-#define OCCA_NOT_FOUND           9
+#define OCCA_PPC_VENDOR          9
+#define OCCA_NOT_FOUND           10
 
 int main(int argc, char **argv) {
 
@@ -36,6 +37,9 @@ int main(int argc, char **argv) {
 
 #elif defined(__clang__)
   return OCCA_LLVM_VENDOR;
+
+#elif defined(__powerpc__)
+  return OCCA_PPC_VENDOR;
 
 // Clang also defines __GNUC__, so check for it after __clang__
 #elif defined(__GNUC__) || defined(__GNUG__)

--- a/nekBone/setup.cpp
+++ b/nekBone/setup.cpp
@@ -421,7 +421,7 @@ void solveSetup(BP_t* BP, occa::properties &kernelInfo)
   //use the masked ids to make another gs handle
   //BP->ogs = ogsSetup(Ntotal, mesh->maskedGlobalIds, mesh->comm, 1, mesh->device);
   auto callback = [&]() {
-                    if(!BP->overlap) return;
+                    if(!BP->overlap || !mesh->NlocalGatherElements) return;
 
                     mesh_t* mesh = BP->mesh;
                     const dlong fieldOffset = BP->fieldOffset;

--- a/nekBone/solve.cpp
+++ b/nekBone/solve.cpp
@@ -329,14 +329,15 @@ dfloat AxOperator(BP_t* BP, occa::memory &o_lambda, occa::memory &o_q, occa::mem
     //ogsGatherScatterStart(o_Aq, ogsDfloat, ogsAdd, ogs);
     oogs::start(o_Aq, ogsDfloat, ogsAdd, ogs);
     if(BP->profiling) timer::tic("Ax2");
-    kernel(mesh->NlocalGatherElements,
-           fieldOffset,
-           mesh->o_localGatherElementList,
-           mesh->o_ggeo,
-           mesh->o_D,
-           o_lambda,
-           o_q,
-           o_Aq);
+    if(mesh->NlocalGatherElements)
+      kernel(mesh->NlocalGatherElements,
+            fieldOffset,
+            mesh->o_localGatherElementList,
+            mesh->o_ggeo,
+            mesh->o_D,
+            o_lambda,
+            o_q,
+            o_Aq);
     if(BP->profiling) timer::toc("Ax2");
     //ogsGatherScatterFinish(o_Aq, ogsDfloat, ogsAdd, ogs);
     oogs::finish(o_Aq, ogsDfloat, ogsAdd, ogs);


### PR DESCRIPTION
This pull request aims to fix two things that were introduced to the code in the past few days:

1. The kernel on the interior elements should only be called if there actually are any interior elements (when overlapping gs+ax), otherwise the code will crash at runtime.

2. The compile flag `-march=native` does not exist in GCC on PowerPC and causes compilation to fail. PowerPC is now an additional vendor option in shellTools.sh that uses `-mcpu=native -mtune=native` instead.